### PR TITLE
Create database "on-the-fly"

### DIFF
--- a/building_energy_standards_data/applications/database_maintenance.py
+++ b/building_energy_standards_data/applications/database_maintenance.py
@@ -1,5 +1,6 @@
 import sqlite3
 import logging
+import os
 
 import building_energy_standards_data.database_tables as tables
 from building_energy_standards_data.database_engine.assertions import assert_
@@ -7,6 +8,8 @@ from building_energy_standards_data.database_engine.database_util import (
     read_csv_to_list_dict,
     read_json_to_list_dict,
 )
+
+ROOT_DIR = os.path.dirname(__file__)
 
 
 def create_openstudio_standards_database_from_csv(conn: sqlite3.Connection):
@@ -24,19 +27,29 @@ def create_openstudio_standards_database_from_csv(conn: sqlite3.Connection):
                 )
 
 
-def create_openstudio_standards_database_from_json(conn: sqlite3.Connection):
+def create_openstudio_standards_database_from_json(
+    conn: sqlite3.Connection, path_suffix=""
+):
     database_available_tables = tables.__gettables__()
     table_list = [table[1]() for table in database_available_tables]
     with conn:
         for datatable in table_list:
             datatable.create_a_table(conn)
-            data = read_json_to_list_dict(f"{datatable.initial_data_directory}.json")
+            data = read_json_to_list_dict(
+                f"{path_suffix}{datatable.initial_data_directory}.json"
+            )
             for record in data:
                 logging.info(record)
                 assert_(
                     datatable.add_a_record(conn, record),
                     f"Unsuccessful adding a new record: {record} to table {datatable.data_table_name}",
                 )
+
+
+def create_database(conn: sqlite3.Connection):
+    create_openstudio_standards_database_from_json(
+        conn, path_suffix=f"{ROOT_DIR}/../../"
+    )
 
 
 def export_openstudio_standards_database_to_csv(conn: sqlite3.Connection, save_dir=""):

--- a/docs/QuickStartGuide.md
+++ b/docs/QuickStartGuide.md
@@ -1,5 +1,7 @@
 ## Quick Start Guide
 Please note that if you have installed the database with `pip` you will need to add `import building_energy_standards_data` at the beginning of the code snippets shown below. Otherwise, if you are running the following code snippets from a clone of the repository, make sure to run them from the root directory.
+
+Also, if installing the database using `pip`, one should use `create_database()` in place of `create_openstudio_standards_database_from_json()` or `create_openstudio_standards_database_from_csv()`.
 ### Create the Database
 ```python
 import sqlite3


### PR DESCRIPTION
Add a new platform agnostic function to create the database when `building-energy-standards-data` is used in a script. The only change really is to add a suffix to the initial data directory so that the package can find the JSON files.