### PR TITLE
add catalog-info.yaml file for forge catalog integration

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,29 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: building-energy-standards-data
+  title: Building Energy Standards Data
+  description: A database of building energy standards data to be used in building energy simulation applications.
+  annotations:
+    # Conditional host-specific annotations rendered to avoid empty-string values that fail catalog validation.
+    github.com/project-slug: pnnl/building-energy-standards-data
+  links:
+    - title: Building Energy Standards Data Repository
+      url: https://github.com/pnnl/building-energy-standards-data
+  tags:
+    - energy
+    - database
+    - simulation
+    - building
+spec:
+  type: database
+  owner: user:default/jeremy.lerond_pnnl.gov # Jeremy Lerond project lead
+  visibility: private # to expose this item in the catalog to others at PNNL, change the visibility to 'public'
+  # system: 
+  lifecycle: production
+
+  # TODO: does building-energy-standards-data depend on another resource or component?
+  # dependsOn:
+
+  # TODO: does another resource depend on building-energy-standards-data? 
+  # dependencyOf:


### PR DESCRIPTION
Add a `catalog-info.yaml` file to root to be ingested in the [Forge Catalog](https://forge.pnnl.gov/catalog). Syncing can take up to an hour for it to populate in the table.

By default, the component will only be visible to the direct owner and Forge admins. If you want this component to be visible to others in the Forge Catalog, please update the visibility field to 'public'

Other attributes can be added/modified as well. Reference to the [Backstage official docs](https://backstage.io/docs/features/software-catalog/descriptor-format/#kind-component)