### PR TITLE
Change default branch for `openstudio-standards` automation

### DIFF
--- a/.github/workflows/trigger_osstd_repo_action.yml
+++ b/.github/workflows/trigger_osstd_repo_action.yml
@@ -31,4 +31,4 @@ jobs:
             -H "Authorization: Bearer ${{ secrets.JERRY_ACTIONS_KEY }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/NREL/openstudio-standards/pulls \
-            -d '{"title":"Building Energy Standards Data Update","body":"Updates have been made to the Building Energy Standards Data repository, see [here](https://github.com/pnnl/building-energy-standards-data/commit/${{ github.sha }}). This pull request was automatically generated.","head":"data_update_${{ steps.updatedata.outputs.shortsha }}","base":"master"}'
+            -d '{"title":"Building Energy Standards Data Update","body":"Updates have been made to the Building Energy Standards Data repository, see [here](https://github.com/pnnl/building-energy-standards-data/commit/${{ github.sha }}). This pull request was automatically generated.","head":"data_update_${{ steps.updatedata.outputs.shortsha }}","base":"develop"}'


### PR DESCRIPTION
Change default branch for `openstudio-standards` automation to `develop` from `master`.