### PR TITLE
Update level_2_lighting_space_types.json to include the 2025 references to the level_3 data.

### DIFF
--- a/building_energy_standards_data/database_files/level_2_lighting_space_types.json
+++ b/building_energy_standards_data/database_files/level_2_lighting_space_types.json
@@ -7498,6 +7498,1077 @@
     },
     {
         "lighting_space_type_name": "airport_concourse_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 150,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 118,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "atrium_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 33,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 178,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "none_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 155,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 0,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "audience_seating_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 36,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 118,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "baggage_carousel_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 149,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 237,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "banking_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 42,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 355,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "classroom_lecture_training_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 43,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 471,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "computer_room_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 45,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 710,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "conference_meeting_multipurpose_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 46,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 355,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "confinement_cells_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 92,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 296,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "copy_print_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 47,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 178,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "corridor_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 48,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 178,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "courtroom_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 49,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 474,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "datacenterhighite_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 54,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 118,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "datacenterlowite_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 54,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 118,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "dining_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 50,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 308,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "dressing_room_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 131,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 237,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "electrical_mechanical_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 54,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 118,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "emergency_room_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 105,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 888,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "emergency_vehicle_garage_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 55,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 355,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "exam_treatment_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 105,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 592,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "exercise_area_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 102,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 474,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "exhibit_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 123,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 431,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "guest_room_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 58,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 178,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "imaging_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 107,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 355,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "interior_parking_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 20,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 54,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "judges_chambers_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 49,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 355,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "food_preparation_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 57,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 538,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "laboratory_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 59,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 592,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "laundry_washing_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 61,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 355,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "library_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 14,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 118,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "living_quarters_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 94,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 178,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "loading_dock_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 62,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 355,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "lobby_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 63,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 296,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "locker_room_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 67,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 237,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "lounge_breakroom_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 68,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 178,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "manufacturing_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 15,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 592,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "medical_supply_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 109,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 355,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "multifamily_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 17,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 178,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "nursery_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 110,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 355,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "nurses_station_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 111,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 355,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "office_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 19,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 414,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "office_enclosed_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 71,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 355,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "operating_room_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 112,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 1184,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "patient_room_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 113,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 355,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "pharmacy_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 109,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 888,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "physical_therapy_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 114,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 474,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "playing_area_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 103,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 592,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "post_office_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 24,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 237,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "recovery_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 115,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 592,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "recreation_common_living_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 68,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 323,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "restroom_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 76,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 178,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "retail_sales_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 77,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 474,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "sleeping_quarters_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 101,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 59,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "sports_arena_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 28,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 1184,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "stairwell_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 80,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 118,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "storage_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 82,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 118,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "transportation_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 30,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 237,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "vehicular_maintenance_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 83,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 355,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "workshop_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 32,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 592,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "worship_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 25,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 355,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "ba_automotive_facility_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 1,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 355,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "ba_convention_center_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 2,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 118,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "ba_courthouse_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 3,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 474,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "ba_dining_bar_lounge_leisure_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 4,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 118,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "ba_dining_cafeteria_fast_food_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 5,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 237,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "ba_dining_family_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 6,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 237,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "ba_dormitory_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 7,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 178,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "ba_exercise_center_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 8,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 237,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "ba_fire_station_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 9,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 118,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "ba_gymnasium_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 10,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 237,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "ba_health-care_clinic_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 11,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 592,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "ba_hospital_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 12,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 592,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "ba_hotel_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 13,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 178,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "ba_motel_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 13,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 178,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "ba_motion_picture_theater_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 16,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 118,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "ba_museum_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 18,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 118,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "ba_parking_garage_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 20,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 54,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "ba_penitentiary_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 21,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 296,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "ba_performing_arts_theater_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 22,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 426,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "ba_police_station_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 23,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 118,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "ba_school_university_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 27,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 471,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "ba_town_hall_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 29,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 355,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "ba_retail_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 26,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 474,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "ba_warehouse_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 31,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 118,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "audience_seating_area_for_gymnasium_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 38,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 118,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "audience_seating_area_for_motion_picture_theater_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 39,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 118,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "audience_seating_area_for_penitentiary_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 90,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 355,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "audience_seating_area_for_performing_arts_theater_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 40,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 426,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "audience_seating_area_for_religious_buildings_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 128,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 118,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "audience_seating_area_for_sports_arena_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 41,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 118,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "classroom_lecture_training_for_penitentiary_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 91,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 471,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "corridor_transition_for_hospital_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 106,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 355,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "dining_area_for_penitentiary_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 93,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 178,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "dining_bar_lounge_leisure_general_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 51,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 118,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "dining_cafeteria_fast_food_general_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 52,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 237,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "dining_area_for_family_dining_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 53,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 237,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "lobby_for_hotel_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 63,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 178,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "lobby_for_motion_picture_theater_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 65,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 118,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "lobby_for_performing_arts_theater_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 66,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 296,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "lounge_recreation_for_hospital_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 108,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 296,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "office-enclosed_general_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 71,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 355,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "office_open_plan_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 72,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 414,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "automotive_general_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 83,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 355,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "convention_center_exhibit_space_general_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 89,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 431,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "library_reading_area_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 117,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 592,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "library_stacks_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 118,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 355,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "manufacturing_facility_detailed_manufacturing_area_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 119,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 592,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "manufacturing_facility_equipment_room_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 56,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 237,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "manufacturing_facility_high_bay_area_25_to_50_ft_ftc_hgt_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 121,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 592,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "manufacturing_facility_low_bay_area_lt_25_ft_ftc_hgt_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 122,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 592,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "museum_restoration_room_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 124,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 592,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "post_office_sorting_area_general_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 127,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 474,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "religious_buildings_fellowship_hall_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 129,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 355,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "religious_buildings_worship_pulpit_choir_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 130,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 355,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "retail_mall_concourse_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 133,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 403,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "transportation_facility_ticket_counter_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 152,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 296,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "warehouse_storage_area_medium_to_bulky_palletized_items_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 153,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 237,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "warehouse_storage_area_smaller_hand-carried_items_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025",
+        "level_3_lighting_code_definition_id": 153,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 355,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "airport_concourse_lighting",
         "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2004_prm",
         "level_3_lighting_code_definition_id": 122,
         "lighting_technology_name": "default",
@@ -14987,6 +16058,1077 @@
     {
         "lighting_space_type_name": "warehouse_storage_area_smaller_hand-carried_items_lighting",
         "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2022_prm",
+        "level_3_lighting_code_definition_id": 153,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 355,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "airport_concourse_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 149,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 118,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "atrium_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 33,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 178,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "none_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 154,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 0,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "audience_seating_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 36,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 118,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "baggage_carousel_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 148,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 237,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "banking_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 43,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 355,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "classroom_lecture_training_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 44,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 471,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "computer_room_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 46,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 710,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "conference_meeting_multipurpose_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 47,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 355,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "confinement_cells_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 97,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 296,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "copy_print_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 48,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 178,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "corridor_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 49,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 178,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "courtroom_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 50,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 474,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "datacenterhighite_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 55,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 118,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "datacenterlowite_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 55,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 118,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "dining_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 51,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 308,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "dressing_room_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 134,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 237,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "electrical_mechanical_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 55,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 118,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "emergency_room_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 110,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 888,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "emergency_vehicle_garage_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 56,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 355,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "exam_treatment_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 110,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 592,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "exercise_area_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 107,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 474,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "exhibit_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 127,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 431,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "guest_room_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 59,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 178,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "imaging_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 109,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 355,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "interior_parking_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 20,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 54,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "judges_chambers_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 50,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 355,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "food_preparation_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 58,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 538,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "laboratory_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 60,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 592,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "laundry_washing_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 62,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 355,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "library_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 14,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 118,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "living_quarters_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 99,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 178,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "loading_dock_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 63,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 355,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "lobby_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 64,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 296,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "locker_room_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 69,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 237,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "lounge_breakroom_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 70,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 178,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "manufacturing_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 15,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 592,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "medical_supply_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 113,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 355,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "multifamily_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 17,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 178,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "nursery_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 114,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 355,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "nurses_station_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 115,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 355,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "office_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 19,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 414,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "office_enclosed_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 73,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 355,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "operating_room_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 116,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 1184,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "patient_room_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 117,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 355,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "pharmacy_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 113,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 888,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "physical_therapy_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 118,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 474,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "playing_area_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 108,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 592,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "post_office_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 24,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 237,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "recovery_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 119,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 592,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "recreation_common_living_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 70,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 323,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "restroom_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 78,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 178,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "retail_sales_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 79,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 474,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "sleeping_quarters_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 106,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 59,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "sports_arena_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 28,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 1184,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "stairwell_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 84,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 118,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "storage_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 85,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 118,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "transportation_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 30,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 237,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "vehicular_maintenance_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 87,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 355,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "workshop_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 32,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 592,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "worship_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 25,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 355,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "ba_automotive_facility_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 1,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 355,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "ba_convention_center_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 2,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 118,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "ba_courthouse_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 3,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 474,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "ba_dining_bar_lounge_leisure_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 4,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 118,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "ba_dining_cafeteria_fast_food_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 5,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 237,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "ba_dining_family_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 6,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 237,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "ba_dormitory_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 7,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 178,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "ba_exercise_center_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 8,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 237,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "ba_fire_station_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 9,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 118,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "ba_gymnasium_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 10,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 237,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "ba_health-care_clinic_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 11,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 592,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "ba_hospital_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 12,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 592,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "ba_hotel_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 13,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 178,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "ba_motel_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 13,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 178,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "ba_motion_picture_theater_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 16,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 118,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "ba_museum_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 18,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 118,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "ba_parking_garage_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 20,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 54,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "ba_penitentiary_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 21,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 296,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "ba_performing_arts_theater_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 22,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 426,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "ba_police_station_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 23,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 118,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "ba_school_university_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 27,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 471,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "ba_town_hall_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 29,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 355,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "ba_retail_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 26,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 474,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "ba_warehouse_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 31,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 118,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "audience_seating_area_for_gymnasium_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 39,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 118,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "audience_seating_area_for_motion_picture_theater_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 40,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 118,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "audience_seating_area_for_penitentiary_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 95,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 355,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "audience_seating_area_for_performing_arts_theater_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 41,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 426,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "audience_seating_area_for_religious_buildings_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 131,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 118,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "audience_seating_area_for_sports_arena_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 42,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 118,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "classroom_lecture_training_for_penitentiary_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 96,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 471,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "corridor_transition_for_hospital_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 111,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 355,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "dining_area_for_penitentiary_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 98,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 178,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "dining_bar_lounge_leisure_general_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 52,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 118,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "dining_cafeteria_fast_food_general_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 53,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 237,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "dining_area_for_family_dining_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 54,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 237,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "lobby_for_hotel_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 66,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 178,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "lobby_for_motion_picture_theater_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 67,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 118,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "lobby_for_performing_arts_theater_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 68,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 296,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "lounge_recreation_for_hospital_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 112,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 296,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "office-enclosed_general_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 73,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 355,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "office_open_plan_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 74,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 414,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "automotive_general_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 87,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 355,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "convention_center_exhibit_space_general_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 94,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 431,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "library_reading_area_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 121,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 592,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "library_stacks_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 122,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 355,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "manufacturing_facility_detailed_manufacturing_area_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 123,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 592,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "manufacturing_facility_equipment_room_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 57,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 237,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "manufacturing_facility_high_bay_area_25_to_50_ft_ftc_hgt_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 125,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 592,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "manufacturing_facility_low_bay_area_lt_25_ft_ftc_hgt_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 124,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 592,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "museum_restoration_room_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 128,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 592,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "post_office_sorting_area_general_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 130,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 474,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "religious_buildings_fellowship_hall_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 132,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 355,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "religious_buildings_worship_pulpit_choir_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 133,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 355,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "retail_mall_concourse_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 137,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 403,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "transportation_facility_ticket_counter_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 151,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 296,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "warehouse_storage_area_medium_to_bulky_palletized_items_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
+        "level_3_lighting_code_definition_id": 152,
+        "lighting_technology_name": "default",
+        "lighting_space_type_target_illuminance_setpoint": 237,
+        "lighting_space_type_target_illuminance_setpoint_unit": "Lux",
+        "annotation": "Illuminance setpoint values have been determined based on the \"2019\" total horizontal illuminance values based on IES"
+    },
+    {
+        "lighting_space_type_name": "warehouse_storage_area_smaller_hand-carried_items_lighting",
+        "level_3_lighting_code_definition_table": "level_3_lighting_90_1_2025_prm",
         "level_3_lighting_code_definition_id": 153,
         "lighting_technology_name": "default",
         "lighting_space_type_target_illuminance_setpoint": 355,


### PR DESCRIPTION
# Pull request overview
<!-- Please be sure to review the Developer Documentation before submitting a pull request -->
<!-- https://github.com/pnnl/building-energy-standards-data/blob/develop/docs/DeveloperNotes.md -->

This PR fixes #172 by wiring the existing 2025 level-3 lighting data into the space map by adding the missing level-2 mappings, restoring 90.1-2025 interior lighting export to full parity with 2022 and below.

## Description
<!-- Provide a description of the pull request -->

Single file change for `building_energy_standards_data/database_files/level_2_lighting_space_types.json`  with 238 new rows (119 standard + 119 PRM), one per existing 2022 mapping row, with `level_3_lighting_code_definition_table` set to `level_3_lighting_90_1_2025` / `level_3_lighting_90_1_2025_prm`.

**Key implementation detail: ids are remapped, not copied.**

`level_3_lighting_code_definition_id` is the level-3 row's autoincrement PRIMARY KEY (= position in the level-3 table). 2025 has 157 rows vs 2022's 158 (90.1-2025 removed the `Lobby / Hotel` category), so positions shift and a copied id would point at the wrong LPD. Each 2025 id is therefore resolved by matching the source row's `(lighting_primary_space_type, lighting_secondary_space_type)` to the same pair in the 2025 table.

The `Lobby / Hotel` category, removed in 90.1-2025, is remapped to `Lobby / All other lobbies`. All other categories are matched exactly to 90.1-2022.

Finally, the file groups rows in contiguous per-table blocks (all standard 2004→2022, then all PRM, then IECC). The new `…2025` block is inserted directly after the `…2022` block and `…2025_prm` directly after `…2022_prm`. All pre-existing rows are unchanged and the structure is preserved.

## Type of Change
<!-- Mark with an "x" all that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactor/cleanup
- [ ] Performance improvement
- [ ] Database schema change

## Related Issues
<!-- Link any related issues here -->
<!-- Fixes #123, Closes #456, Relates to #789 -->
Fixes #172 

## Testing
<!-- Describe the tests that you ran to verify your changes -->
<!-- Provide instructions so we can reproduce -->

Verified locally by reading the built database. The script below builds the DB from the data files and, for both the pre-fix (`HEAD~1`) and post-fix states, reports three numbers: `level_2` rows referencing the 2025 level-3 lighting tables, space-map rows the generator sees for `90_1_2025`, and design space types actually exported for `version_90_1="2025"`.

```python
import os, sqlite3, json, tempfile, subprocess
import building_energy_standards_data as besd
from building_energy_standards_data.applications.database_maintenance import (
    create_openstudio_standards_database_from_json)
from building_energy_standards_data.applications.create_openstudio_standards_json import (
    create_openstudio_standards_space_data_json_ashrae_90_1, fetch_space_data)

REPO = os.path.dirname(os.path.dirname(besd.__file__))
L2 = f"{REPO}/building_energy_standards_data/database_files/level_2_lighting_space_types.json"

def measure(tag):
    db = f"/tmp/osstd_{tag.strip()}.db"
    if os.path.exists(db):
        os.remove(db)
    conn = sqlite3.connect(db)
    create_openstudio_standards_database_from_json(conn, path_suffix=f"{REPO}/")
    cur = conn.cursor()
    l2 = cur.execute("SELECT COUNT(*) FROM level_2_lighting_space_types "
                     "WHERE level_3_lighting_code_definition_table LIKE '%90_1_2025%'").fetchone()[0]
    sm = sum(1 for r in fetch_space_data(conn)
             if "90_1_2025" in r["level_3_lighting_code_definition_table"])
    with tempfile.TemporaryDirectory() as t:
        dd = f"{t}/lib/openstudio-standards/standards/ashrae_90_1/ashrae_90_1_2025/data"
        os.makedirs(dd)
        create_openstudio_standards_space_data_json_ashrae_90_1(conn, "2025", osstd_repository_path=t)
        n = len(json.load(open(f"{dd}/ashrae_90_1_2025.space_types.json"))["space_types"])
    conn.close()
    print(f"[{tag}]  level_2 rows ref 90_1_2025 = {l2:<4} | "
          f"space-map rows ref 90_1_2025 = {sm:<4} | 2025 space types exported = {n}")

# after = committed fix; before = its parent commit (temporarily restore, then put the file back)
current = open(L2).read()
before = subprocess.check_output(
    ["git", "-C", REPO, "show",
     "HEAD~1:building_energy_standards_data/database_files/level_2_lighting_space_types.json"]).decode()
try:
    open(L2, "w").write(before);  measure("before")
    open(L2, "w").write(current); measure("after ")
finally:
    open(L2, "w").write(current) 
```

Output:

```
[before]  level_2 rows ref 90_1_2025 = 0    | space-map rows ref 90_1_2025 = 0    | 2025 space types exported = 0
[after ]  level_2 rows ref 90_1_2025 = 238  | space-map rows ref 90_1_2025 = 704  | 2025 space types exported = 61
```


I ran the Python tests and checked against `black`, but nothing changed on the Python code, so as expected, everything returned fine.

- [x] Unit tests pass locally
- [x] Integration tests pass locally


## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

N/A data-only change.

## Items to complete before requesting a review
- [x] All unit tests pass and follow [Black](https://github.com/psf/black) formatting standards
- [ ] New code includes unit tests (except database table additions)
   - This is a database data addition (no new code logic), so the exception applies.
- [ ] Documentation updated if changes affect database structure or contribution process
   - N/A; no schema change.
- [x] Code is well-documented and thoroughly tested
   - Minimal documentation for a data change, instead 

## Additional Notes
<!-- Any additional information that reviewers should know -->
- The fix follows the guide's "add the lowest level (level 3) first, then map to the parent level (level 2)" workflow — the level-3 2025 data already existed; this PR supplies the missing level-2 mapping.
- Scope is the interior lighting space-type mapping for both the standard and PRM (Appendix G) paths.
- Out of scope: there are mislabeled `annotation: "From 90.1-2022 Table 9.5.1"` strings in `level_3_lighting_90_1_2025.json` (minor).